### PR TITLE
Corrige tag html

### DIFF
--- a/Variaveis/index.php
+++ b/Variaveis/index.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"
+<html lang="en">
 
 <head>
 


### PR DESCRIPTION
Faltou o `>` quando abriu a tag html.